### PR TITLE
Fixed comments on posts are not being deleted. #1

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
This pull request fixed issue #1, which caused comments on posts not to be deleted after the admin deleted them. 

The issue was not committing the delete in the database, which is resolved using `db.session.commit()` on line 365 in `albumy/blueprints/main.py.`