### PR TITLE
Fixed Comments on posts are not being deleted. #1

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
This PR solves issue #1 

I added `db.session.commit()` function to finalize delete call in line 365 of the `albumy/blueprints/main.py` file

When tested, this fixed the bug
