### PR TITLE
Fixed bug of not deleting comments

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
This pull request closes #1 that the comments are not being deleted.

The issue was the changes to the comment were not being committed to the database. As a result, the delete did not happen. 

This pull request adds the line of code that does the commit, and it solves the issue.