### PR TITLE
Fixed bug so that comments delete properly now (issue #1)

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Resolved issue #1. Fixed a bug so that comments that are now actually deleted from database when the user pressed the delete option in the overflow menu on a post comment.