### PR TITLE
Fix bug where comments were not being deleted

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
### Description ###
Resolves #1 by committing database delete changes to the repository. 

### How has this been tested? ###
Login as the admin account and delete a comment on a post. When the post reloads, the comment should not be there anymore.



