### PR TITLE
commit functionality added to delete comment function.

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
Resolved issue #1 by adding the line "db.session.commit()" after the comment is deleted from the database because the issue was occurring since the action of deleting hadn't been committed, therefore it was not registering the new change on the frontend. 