### PR TITLE
Fixed the bug by adding db.session.commit()

### DIFF
--- a/albumy/blueprints/main.py
+++ b/albumy/blueprints/main.py
@@ -362,6 +362,7 @@ def delete_comment(comment_id):
             and not current_user.can('MODERATE'):
         abort(403)
     db.session.delete(comment)
+    db.session.commit()
     flash('Comment deleted.', 'info')
     return redirect(url_for('.show_photo', photo_id=comment.photo_id))
 


### PR DESCRIPTION
When I looked at other delete functions, like delete_photo, I noticed that other delete functions had a db.commit.session() that was missing in the delete_comment function. Hence, I tried adding it to the delete_comment function, and tested it on the local server, and it worked. So, the bug was fixed. 